### PR TITLE
Implement audio playback highlighting

### DIFF
--- a/agent_jobs/005_audio_playback_highlighting.md
+++ b/agent_jobs/005_audio_playback_highlighting.md
@@ -1,0 +1,29 @@
+# Job 005: Audio Playback and Highlighting
+
+- **Issue**: [issues/004_audio_playback_highlighting.md](../issues/004_audio_playback_highlighting.md)
+- **Description**: Implement playback controls and synchronized highlighting during audio playback.
+
+## Summary of Changes
+- Added new state and methods in `usePlaybackStore.js` to handle audio playback and highlighting.
+- Created `PlaybackControls.vue` component with play, pause, and stop buttons.
+- Updated `ContentViewer.vue` to apply `highlight-line` and `highlight-word` classes based on store state.
+- Updated `App.vue` to fetch audio from the backend and start playback when a word is clicked.
+- Added highlight styles in `style.css`.
+
+## Commands Used
+- `pip install -r backend/requirements.txt`
+- `black backend`
+- `flake8 backend`
+- `npm install` (frontend)
+- `npx eslint . --config eslint.config.js`
+- `npx prettier --write .`
+- `npm test` *(fails: Missing script)*
+- `pytest`
+
+## Output
+- Flake8 log: `/tmp/flake8.log`
+- ESLint log: `/tmp/eslint.log`
+- Prettier log: `/tmp/prettier.log`
+- npm install log: `/tmp/npm_install.log`
+- npm test log: `/tmp/npm_test.log`
+- Pytest log: `/tmp/pytest.log`

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,9 +1,15 @@
 <script setup>
 import MarkdownInput from './components/MarkdownInput.vue';
 import ContentViewer from './components/ContentViewer.vue';
+import PlaybackControls from './components/PlaybackControls.vue';
+import { usePlaybackStore } from './composables/usePlaybackStore';
 
-function handleRead(wordId) {
-  console.log('read from', wordId);
+const store = usePlaybackStore();
+
+async function handleRead(wordId) {
+  const index = Number(wordId.split('-')[1]) - 1;
+  const words = store.rawMarkdown.value.split(/\s+/).slice(index);
+  await store.fetchAudioAndPlay(words.join(' '), index);
 }
 </script>
 
@@ -11,5 +17,6 @@ function handleRead(wordId) {
   <div id="app">
     <MarkdownInput />
     <ContentViewer @read-from-word="handleRead" />
+    <PlaybackControls />
   </div>
 </template>

--- a/frontend/src/components/ContentViewer.vue
+++ b/frontend/src/components/ContentViewer.vue
@@ -1,11 +1,43 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
 import { usePlaybackStore } from '../composables/usePlaybackStore';
 
 const store = usePlaybackStore();
 const emit = defineEmits(['read-from-word']);
 
 const rendered = computed(() => store.renderedContent.value);
+
+watch(
+  () => store.currentLineId.value,
+  (newId, oldId) => {
+    if (oldId) {
+      document
+        .querySelector(`[data-line-id="${oldId}"]`)
+        ?.classList.remove('highlight-line');
+    }
+    if (newId) {
+      document
+        .querySelector(`[data-line-id="${newId}"]`)
+        ?.classList.add('highlight-line');
+    }
+  },
+);
+
+watch(
+  () => store.currentWordId.value,
+  (newId, oldId) => {
+    if (oldId) {
+      document
+        .querySelector(`[data-word-id="${oldId}"]`)
+        ?.classList.remove('highlight-word');
+    }
+    if (newId) {
+      document
+        .querySelector(`[data-word-id="${newId}"]`)
+        ?.classList.add('highlight-word');
+    }
+  },
+);
 
 function handleClick(event) {
   const target = event.target.closest('[data-word-id]');

--- a/frontend/src/components/PlaybackControls.vue
+++ b/frontend/src/components/PlaybackControls.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { usePlaybackStore } from '../composables/usePlaybackStore';
+
+const store = usePlaybackStore();
+</script>
+
+<template>
+  <div class="playback-controls">
+    <button
+      @click="store.play"
+      :disabled="store.isPlaying.value || !store.audio.value"
+    >
+      Play
+    </button>
+    <button @click="store.pause" :disabled="!store.isPlaying.value">
+      Pause
+    </button>
+    <button @click="store.stop">Stop</button>
+  </div>
+</template>

--- a/frontend/src/composables/usePlaybackStore.js
+++ b/frontend/src/composables/usePlaybackStore.js
@@ -4,6 +4,54 @@ const rawMarkdown = ref('');
 const renderedContent = shallowRef('');
 const currentLineId = ref(null);
 const currentWordId = ref(null);
+const audio = shallowRef(null);
+const timings = shallowRef([]);
+const isPlaying = ref(false);
+const wordOffset = ref(0);
+
+function clearHighlight() {
+  currentLineId.value = null;
+  currentWordId.value = null;
+}
+
+function stop() {
+  if (audio.value) {
+    audio.value.pause();
+    audio.value.currentTime = 0;
+  }
+  isPlaying.value = false;
+  clearHighlight();
+}
+
+function play() {
+  if (!audio.value) return;
+  isPlaying.value = true;
+  audio.value.play();
+  timings.value.forEach((t, idx) => {
+    setTimeout(() => {
+      const wordId = `word-${wordOffset.value + idx + 1}`;
+      currentWordId.value = wordId;
+      const el = document.querySelector(`[data-word-id="${wordId}"]`);
+      currentLineId.value =
+        el?.closest('[data-line-id]')?.getAttribute('data-line-id') || null;
+    }, t.startTime * 1000);
+  });
+  audio.value.onended = stop;
+}
+
+async function fetchAudioAndPlay(text, offset = 0) {
+  const resp = await fetch('/api/tts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+  const data = await resp.json();
+  const url = `data:${data.mimeType};base64,${data.audioContent}`;
+  audio.value = new Audio(url);
+  timings.value = data.timings;
+  wordOffset.value = offset;
+  play();
+}
 
 export function usePlaybackStore() {
   return {
@@ -11,5 +59,12 @@ export function usePlaybackStore() {
     renderedContent,
     currentLineId,
     currentWordId,
+    audio,
+    timings,
+    isPlaying,
+    fetchAudioAndPlay,
+    play,
+    pause: () => audio.value?.pause(),
+    stop,
   };
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -77,3 +77,9 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+.highlight-line {
+  background-color: rgba(255, 255, 0, 0.2);
+}
+.highlight-word {
+  background-color: rgba(255, 165, 0, 0.6);
+}


### PR DESCRIPTION
## Summary
- implement audio playback controls and highlighting
- fetch audio from backend and track word/line ids
- add CSS highlight styles
- document work in job summary

## Testing
- `pip install -r backend/requirements.txt`
- `black backend`
- `flake8 backend`
- `npm install` (frontend)
- `npx eslint . --config eslint.config.js`
- `npx prettier --write .`
- `npm test` *(fails: Missing script)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6852ccfacdfc8331bb94d5c063844143