### PR TITLE
Implement API URL environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ This project provides a basic setup for a Vue.js frontend and Flask backend.
 
 Both servers will run locally and communicate via HTTP APIs.
 
+### Environment Variables
+
+The frontend expects an environment variable `VITE_API_URL` pointing to the back-end API.
+Create the following files under `frontend/`:
+
+```bash
+echo "VITE_API_URL=http://localhost:5000/api" > frontend/.env.development
+echo "VITE_API_URL=/api" > frontend/.env.production
+```
+
+Vite will use the appropriate file based on the build mode.
+
 ## Testing
 
 ### Frontend

--- a/agent_jobs/007_api_env_support.md
+++ b/agent_jobs/007_api_env_support.md
@@ -1,0 +1,25 @@
+# Job 007: API Environment Support
+
+- **Issue**: [issues/007_api_env_support.md](../issues/007_api_env_support.md)
+- **Description**: Configure environment variables for API URL and update frontend code to use it.
+
+## Summary of Changes
+- Added `.env.development` and `.env.production` files with `VITE_API_URL`.
+- Updated `usePlaybackStore.js` to fetch the API using `import.meta.env.VITE_API_URL`.
+- Documented setup in `README.md`.
+- Fixed flake8 line-length errors in `piper_wrapper.py`.
+
+## Commands Used
+- `npm install`
+- `npx prettier --write .`
+- `npx eslint .`
+- `black backend`
+- `flake8 backend`
+- `pytest`
+- `npm test -- --run`
+
+## Output
+- ESLint log: `/tmp/eslint.log`
+- Prettier log: `/tmp/prettier.log`
+- Pytest log: `/tmp/pytest.log`
+- Vitest log: `/tmp/npm_test.log`

--- a/backend/piper_wrapper.py
+++ b/backend/piper_wrapper.py
@@ -10,7 +10,9 @@ from typing import Dict, List
 class PiperWrapper:
     """Manage a Piper TTS subprocess."""
 
-    def __init__(self, executable: str = "piper", voice: str | None = None) -> None:
+    def __init__(
+        self, executable: str = "piper", voice: str | None = None
+    ) -> None:  # noqa: E501
         cmd = [executable]
         if voice:
             cmd.extend(["--voice", voice])
@@ -39,14 +41,18 @@ class PiperWrapper:
             out_wav = Path(tmpdir) / "output.wav"
             timings_path = Path(tmpdir) / "timings.json"
 
-            request = json.dumps({"text": text, "output_path": str(out_wav)})
+            request = json.dumps(
+                {"text": text, "output_path": str(out_wav)}
+            )  # noqa: E501
             self.process.stdin.write(request + "\n")
             self.process.stdin.flush()
 
             # Read response JSON from Piper
             response_line = self.process.stdout.readline()
             if not response_line:
-                stderr = self.process.stderr.read() if self.process.stderr else ""
+                stderr = (
+                    self.process.stderr.read() if self.process.stderr else ""
+                )  # noqa: E501
                 raise RuntimeError(f"Piper failed: {stderr}")
             resp = json.loads(response_line)
 
@@ -61,11 +67,17 @@ class PiperWrapper:
                 start = 0.0
                 for word in text.split():
                     timings.append(
-                        {"word": word, "startTime": start, "endTime": start + 0.2}
+                        {
+                            "word": word,
+                            "startTime": start,
+                            "endTime": start + 0.2,
+                        }  # noqa: E501
                     )
                     start += 0.2
 
-            audio_b64 = base64.b64encode(out_wav.read_bytes()).decode("ascii")
+            audio_b64 = base64.b64encode(out_wav.read_bytes()).decode(
+                "ascii"
+            )  # noqa: E501
 
         return {
             "audioContent": audio_b64,
@@ -79,7 +91,9 @@ class PiperWrapper:
         timings: List[Dict[str, float]] = []
         start = 0.0
         for word in words:
-            timings.append({"word": word, "startTime": start, "endTime": start + 0.2})
+            timings.append(
+                {"word": word, "startTime": start, "endTime": start + 0.2}
+            )  # noqa: E501
             start += 0.2
         # create 1 second of silence as WAV
         with tempfile.NamedTemporaryFile(suffix=".wav") as tmp:
@@ -90,8 +104,14 @@ class PiperWrapper:
                 b"\x64\x61\x74\x61\x00\x00\x00\x00"
             )
             tmp.flush()
-            audio = base64.b64encode(Path(tmp.name).read_bytes()).decode("ascii")
-        return {"audioContent": audio, "mimeType": "audio/wav", "timings": timings}
+            audio = base64.b64encode(Path(tmp.name).read_bytes()).decode(
+                "ascii"
+            )  # noqa: E501
+        return {
+            "audioContent": audio,
+            "mimeType": "audio/wav",
+            "timings": timings,
+        }  # noqa: E501
 
     def terminate(self) -> None:
         if self.process.poll() is None:

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000/api

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=/api

--- a/frontend/src/composables/usePlaybackStore.js
+++ b/frontend/src/composables/usePlaybackStore.js
@@ -1,5 +1,7 @@
 import { ref, shallowRef } from 'vue';
 
+const API_BASE = import.meta.env.VITE_API_URL || '';
+
 const rawMarkdown = ref('');
 const renderedContent = shallowRef('');
 const currentLineId = ref(null);
@@ -40,7 +42,7 @@ function play() {
 }
 
 async function fetchAudioAndPlay(text, offset = 0) {
-  const resp = await fetch('/api/tts', {
+  const resp = await fetch(`${API_BASE}/tts`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ text }),


### PR DESCRIPTION
## Summary
- add `.env` files for development and production API URLs
- make `usePlaybackStore.js` read `VITE_API_URL`
- document environment variable setup in README
- silence flake8 line-length warnings in `piper_wrapper.py`
- record job details

## Testing
- `npm install`
- `npx prettier --write .`
- `npx eslint . --config eslint.config.js`
- `black backend`
- `flake8 backend`
- `pytest`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6852eaa7194083319e55ee51f2a2e80e