### PR TITLE
Resolve CORS error

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This project provides a basic setup for a Vue.js frontend and Flask backend.
    ```bash
    flask --app app run
    ```
+   The backend uses `flask-cors` to allow requests from the frontend during development.
 
 Both servers will run locally and communicate via HTTP APIs.
 

--- a/agent_jobs/008_cors_support.md
+++ b/agent_jobs/008_cors_support.md
@@ -1,0 +1,27 @@
+# Job 008: Enable CORS
+
+- **Issue**: [issues/008_cors_error.md](../issues/008_cors_error.md)
+- **Description**: Allow cross-origin requests from the frontend by adding CORS headers in the Flask backend.
+
+## Summary of Changes
+
+- Installed `flask-cors` and enabled it in `backend/app.py`.
+- Added test to verify the `Access-Control-Allow-Origin` header.
+- Updated `requirements.txt` and documentation.
+
+## Commands Used
+
+- `pip install -r backend/requirements.txt`
+- `black backend`
+- `flake8 backend`
+- `npx prettier --write .`
+- `cd frontend && npx eslint .`
+- `cd frontend && npm test -- --run`
+- `cd backend && pytest`
+
+## Output
+
+- Prettier log: `/tmp/prettier.log`
+- ESLint log: `/tmp/eslint.log`
+- Pytest log: `/tmp/pytest.log`
+- Vitest log: `/tmp/npm_test.log`

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,8 +1,10 @@
 from flask import Flask, jsonify, request
+from flask_cors import CORS
 
 from piper_wrapper import PiperWrapper
 
 app = Flask(__name__)
+CORS(app)
 tts = PiperWrapper()
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ platformdirs==4.3.8
 pycodestyle==2.13.0
 pyflakes==3.3.2
 Werkzeug==3.1.3
+flask-cors==4.0.0

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -13,6 +13,7 @@ def test_tts_endpoint():
     client = app.test_client()
     resp = client.post("/api/tts", json={"text": "hello world"})
     assert resp.status_code == 200
+    assert resp.headers.get("Access-Control-Allow-Origin") == "*"
     data = resp.get_json()
     assert "audioContent" in data
     assert "mimeType" in data and data["mimeType"] == "audio/wav"


### PR DESCRIPTION
## Summary
- enable CORS in the Flask backend
- add flask-cors to requirements
- document CORS usage in README
- test header in backend test suite
- record completion in `agent_jobs/008_cors_support.md`

## Testing
- `npx prettier --write .`
- `cd frontend && npx eslint .`
- `cd frontend && npm test -- --run`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6852f505b6d0833189e036c1f0645e0e