### PR TITLE
Add Piper installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ echo "VITE_API_URL=/api" > frontend/.env.production
 
 Vite will use the appropriate file based on the build mode.
 
+### Installing Piper TTS
+
+The backend requires the `piper` executable and a voice model. See
+`backend/INSTALL.md` for setup instructions.
+
 ## Testing
 
 ### Frontend

--- a/agent_jobs/010_piper_installation_docs.md
+++ b/agent_jobs/010_piper_installation_docs.md
@@ -1,0 +1,19 @@
+# Job 010: Piper Installation Docs
+
+- **Issue**: [issues/010_piper_installation_docs.md](../issues/010_piper_installation_docs.md)
+- **Description**: Provide documentation for installing Piper TTS and configuring it with `PiperWrapper`.
+
+## Summary of Changes
+- Added `backend/INSTALL.md` with step-by-step instructions for downloading Piper and a sample voice.
+- Created `backend/README.md` summarizing installation steps and linking to the detailed guide.
+- Updated root `README.md` to reference the new installation guide.
+
+## Commands Used
+- `pip install -r backend/requirements.txt`
+- `black backend`
+- `flake8 backend`
+- `npx prettier --write .`
+- `cd frontend && npm install`
+- `cd frontend && npx eslint .`
+- `cd frontend && npm test -- --run`
+- `cd backend && pytest`

--- a/backend/INSTALL.md
+++ b/backend/INSTALL.md
@@ -1,0 +1,58 @@
+# Installing Piper TTS
+
+This project expects the `piper` executable to be available on your system.
+The following steps show one way to install Piper and an example voice.
+
+## 1. Download Piper
+
+Grab a binary release for your platform from the
+[Piper releases page](https://github.com/rhasspy/piper/releases).
+Extract the archive and place the `piper` binary somewhere on your `PATH`
+(e.g. `/usr/local/bin`).
+
+## 2. Download a Voice Model
+
+Download a voice from the same releases page or from
+[Hugging Face](https://huggingface.co/rhasspy/piper-voices).
+A voice consists of a `.onnx` model file and a matching `.onnx.json` config file.
+Place both files in a directory of your choice.
+
+Example using `curl`:
+
+```bash
+curl -L -o en_US-amy-medium.onnx \
+  https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/amy/medium/en_US-amy-medium.onnx
+curl -L -o en_US-amy-medium.onnx.json \
+  https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/amy/medium/en_US-amy-medium.onnx.json
+```
+
+## 3. Verify Piper
+
+Run Piper directly to confirm it works:
+
+```bash
+echo "Hello from Piper" | \
+  piper --model en_US-amy-medium.onnx --output_file test.wav
+```
+
+Play the resulting `test.wav` to ensure audio was generated.
+
+## 4. Configure `PiperWrapper`
+
+`PiperWrapper` looks for the `piper` executable in your `PATH`. If it is located
+elsewhere, pass the full path when constructing the wrapper in `app.py`:
+
+```python
+from piper_wrapper import PiperWrapper
+
+# tts = PiperWrapper('/opt/piper/piper', 'en_US-amy-medium')
+```
+
+You can also specify the `--voice` argument to set a default voice.
+
+## Troubleshooting
+
+- **piper: command not found** — ensure the binary directory is in your `PATH`.
+- **No such file or directory for voice** — check the paths to your `.onnx` and `.onnx.json` files.
+- **Silent output** — verify that the voice files are compatible with your
+  Piper version.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,21 @@
+# Backend
+
+This directory contains the Flask application that provides the `/api/tts` endpoint.
+It relies on a local installation of [Piper TTS](https://github.com/rhasspy/piper).
+
+## Installing Piper
+
+1. Download a Piper release for your platform and place the `piper` binary on
+   your `PATH`.
+2. Download a voice model (`.onnx` and `.onnx.json`) and keep both files
+   together in a directory.
+3. Test the installation:
+
+   ```bash
+   echo "test" | piper --model en_US-amy-medium.onnx --output_file test.wav
+   ```
+
+4. If `piper` is not on your `PATH`, pass the full path when constructing
+   `PiperWrapper` in `app.py`.
+
+See [INSTALL.md](INSTALL.md) for detailed instructions and troubleshooting tips.


### PR DESCRIPTION
## Summary
- document how to install Piper TTS
- add detailed INSTALL.md with voice download and configuration steps
- reference new docs from the project README

## Testing
- `pip install -r backend/requirements.txt`
- `black backend`
- `flake8 backend`
- `npx prettier --write .`
- `cd frontend && npm install`
- `cd frontend && npx eslint .`
- `cd frontend && npm test -- --run`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6853eccd42c48331aaab25f352d8c0c9