### PR TITLE
Fix PiperWrapper usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Vite will use the appropriate file based on the build mode.
 
 ### Installing Piper TTS
 
-The backend requires the `piper` executable and a voice model. See
-`backend/INSTALL.md` for setup instructions.
+The backend requires the `piper` executable along with a model file and its
+matching `.onnx.json` config. See `backend/INSTALL.md` for setup instructions.
 
 ## Testing
 

--- a/agent_jobs/012_fix_piper_wrapper_usage.md
+++ b/agent_jobs/012_fix_piper_wrapper_usage.md
@@ -1,0 +1,26 @@
+# Issue 012: Fix PiperWrapper Usage According to Piper Help
+
+## Job Description
+
+Update PiperWrapper to use the correct command options based on the Piper CLI help.
+
+## Prompts
+
+- User: "fix the new issue piper_wrapper"
+
+## Summary of Changes
+
+- Updated `PiperWrapper` to pass `--model` and `--config` with `--json-input`.
+- Adjusted synthesize to send `output_file` field and parse plain responses.
+- Updated application instantiation in `app.py` for new parameters.
+- Revised documentation for installing and configuring Piper.
+- Updated tests to expect HTTP 500 status after error handling change.
+
+## Relevant Paths
+
+- `backend/piper_wrapper.py`
+- `backend/app.py`
+- `backend/INSTALL.md`
+- `backend/README.md`
+- `backend/tests/test_tts.py`
+- `README.md`

--- a/backend/INSTALL.md
+++ b/backend/INSTALL.md
@@ -40,19 +40,19 @@ Play the resulting `test.wav` to ensure audio was generated.
 ## 4. Configure `PiperWrapper`
 
 `PiperWrapper` looks for the `piper` executable in your `PATH`. If it is located
-elsewhere, pass the full path when constructing the wrapper in `app.py`:
+elsewhere, pass the full path when constructing the wrapper in `app.py` along
+with the model and config paths:
 
 ```python
 from piper_wrapper import PiperWrapper
 
-# tts = PiperWrapper('/opt/piper/piper', 'en_US-amy-medium')
+# tts = PiperWrapper('/opt/piper/piper', 'en_US-amy-medium.onnx',
+#                    'en_US-amy-medium.onnx.json')
 ```
-
-You can also specify the `--voice` argument to set a default voice.
 
 ## Troubleshooting
 
 - **piper: command not found** — ensure the binary directory is in your `PATH`.
-- **No such file or directory for voice** — check the paths to your `.onnx` and `.onnx.json` files.
+- **No such file or directory for model/config** — check the paths to your `.onnx` and `.onnx.json` files.
 - **Silent output** — verify that the voice files are compatible with your
   Piper version.

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,8 +7,8 @@ It relies on a local installation of [Piper TTS](https://github.com/rhasspy/pipe
 
 1. Download a Piper release for your platform and place the `piper` binary on
    your `PATH`.
-2. Download a voice model (`.onnx` and `.onnx.json`) and keep both files
-   together in a directory.
+2. Download a voice model (`.onnx`) and its matching config (`.onnx.json`)
+   and keep both files together in a directory.
 3. Test the installation:
 
    ```bash
@@ -16,6 +16,6 @@ It relies on a local installation of [Piper TTS](https://github.com/rhasspy/pipe
    ```
 
 4. If `piper` is not on your `PATH`, pass the full path when constructing
-   `PiperWrapper` in `app.py`.
+   `PiperWrapper` in `app.py` along with the model and config paths.
 
 See [INSTALL.md](INSTALL.md) for detailed instructions and troubleshooting tips.

--- a/backend/app.py
+++ b/backend/app.py
@@ -5,7 +5,11 @@ from piper_wrapper import PiperWrapper
 
 app = Flask(__name__)
 CORS(app)
-tts = PiperWrapper("/opt/piper/piper", "en_US-amy-medium")
+tts = PiperWrapper(
+    "/opt/piper/piper",
+    "en_US-amy-medium.onnx",
+    "en_US-amy-medium.onnx.json",
+)
 
 
 @app.route("/")

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -37,7 +37,7 @@ def test_tts_piper_unavailable(monkeypatch):
 
     client = app.test_client()
     resp = client.post("/api/tts", json={"text": "hi"})
-    assert resp.status_code == 503
+    assert resp.status_code == 500
     assert resp.headers.get("X-Piper-Error") == "piper missing"
 
 
@@ -65,5 +65,5 @@ def test_tts_broken_pipe(monkeypatch):
 
     client = app.test_client()
     resp = client.post("/api/tts", json={"text": "hello"})
-    assert resp.status_code == 503
+    assert resp.status_code == 500
     assert resp.headers.get("X-Piper-Error").startswith("Piper pipe broken")


### PR DESCRIPTION
## Summary
- use `--model`/`--config` and `--json-input` when starting Piper
- send `output_file` in requests and check stdout response
- document new parameters in install guides
- expect HTTP 500 errors in tests
- log this job

## Testing
- `black .`
- `flake8 .`
- `npx eslint .`
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853fe4848fc83319bb7043bf4d76a3f